### PR TITLE
feat: add binary and color copy sequencers functionality in ColumnSettingsDropdown

### DIFF
--- a/src/app/editor/components/ColumnSettingsDropdown/index.js
+++ b/src/app/editor/components/ColumnSettingsDropdown/index.js
@@ -126,12 +126,20 @@ const ColumnSettingsDropdown = ({ columnIndex }) => {
 		[updateLights, lights, columnIndex, data.scaleFactor],
 	);
 
-	const handleCopySequencers = useCallback(() => {
+	const handleBinaryCopySequencers = useCallback(() => {
 		const binary = Array.from({ length: totalRows }, (_, rowIndex) => {
 			const color = lights[rowIndex]?.[columnIndex]?.color;
 			return color && color !== "none" ? "1" : "0";
 		}).join("");
 		navigator.clipboard.writeText(binary);
+	}, [lights, columnIndex, totalRows]);
+
+	const handleCopySequencers = useCallback(() => {
+		const sequencers = Array.from({ length: totalRows }, (_, rowIndex) => {
+			const color = lights[rowIndex]?.[columnIndex]?.color;
+			return color && color !== "none" ? color : "none";
+		}).join(",");
+		navigator.clipboard.writeText(sequencers);
 	}, [lights, columnIndex, totalRows]);
 
 	const handleChangeDirection = useCallback(
@@ -191,9 +199,15 @@ const ColumnSettingsDropdown = ({ columnIndex }) => {
 				>
 					<DropdownMenu.Item
 						className="group relative flex h-[25px] select-none items-center rounded-[3px] px-[5px] pl-[25px] text-[13px] text-gray-200 leading-none outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-slate-600/50 data-[disabled]:text-gray-400 data-[highlighted]:text-white"
+						onSelect={handleBinaryCopySequencers}
+					>
+						Copy Sequencers (binary)
+					</DropdownMenu.Item>
+					<DropdownMenu.Item
+						className="group relative flex h-[25px] select-none items-center rounded-[3px] px-[5px] pl-[25px] text-[13px] text-gray-200 leading-none outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-slate-600/50 data-[disabled]:text-gray-400 data-[highlighted]:text-white"
 						onSelect={handleCopySequencers}
 					>
-						Copy Sequencers
+						Copy Sequencers (with colors)
 					</DropdownMenu.Item>
 					<DropdownMenu.Separator className="m-[5px] h-px bg-slate-600" />
 					<DropdownMenu.Item

--- a/src/app/editor/components/ColumnSettingsDropdown/index.js
+++ b/src/app/editor/components/ColumnSettingsDropdown/index.js
@@ -131,7 +131,8 @@ const ColumnSettingsDropdown = ({ columnIndex }) => {
 			const color = lights[rowIndex]?.[columnIndex]?.color;
 			return color && color !== "none" ? "1" : "0";
 		}).join("");
-		navigator.clipboard.writeText(binary);
+		const decimal = Number.parseInt(binary, 2).toString();
+		navigator.clipboard.writeText(decimal);
 	}, [lights, columnIndex, totalRows]);
 
 	const handleCopySequencers = useCallback(() => {
@@ -201,7 +202,7 @@ const ColumnSettingsDropdown = ({ columnIndex }) => {
 						className="group relative flex h-[25px] select-none items-center rounded-[3px] px-[5px] pl-[25px] text-[13px] text-gray-200 leading-none outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-slate-600/50 data-[disabled]:text-gray-400 data-[highlighted]:text-white"
 						onSelect={handleBinaryCopySequencers}
 					>
-						Copy Sequencers (binary)
+						Copy Sequencers (decimal)
 					</DropdownMenu.Item>
 					<DropdownMenu.Item
 						className="group relative flex h-[25px] select-none items-center rounded-[3px] px-[5px] pl-[25px] text-[13px] text-gray-200 leading-none outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-slate-600/50 data-[disabled]:text-gray-400 data-[highlighted]:text-white"

--- a/test/e2e/1-basic/columnSettingsDropdown.spec.ts
+++ b/test/e2e/1-basic/columnSettingsDropdown.spec.ts
@@ -7,7 +7,9 @@ test.describe.serial("ColumnSettingsDropdown", () => {
 	let page: Page;
 
 	test.beforeAll(async ({ browser }) => {
-		const context = await browser.newContext();
+		const context = await browser.newContext({
+			permissions: ["clipboard-read", "clipboard-write"],
+		});
 		page = await context.newPage();
 		await dismissTutorial(page);
 		await page.goto("/editor");
@@ -77,6 +79,26 @@ test.describe.serial("ColumnSettingsDropdown", () => {
 		await page.locator(".swal2-input").fill("-1");
 		await page.locator(".swal2-confirm").click();
 		await expect(page.locator(".swal2-validation-message")).not.toBeVisible();
+	});
+
+	test("should copy sequencers as binary", async () => {
+		await page.locator('[data-testid="column-settings-dropdown"]').first().click();
+		await page.getByText("Copy Sequencers (binary)").click();
+
+		const text = await page.evaluate(() => navigator.clipboard.readText());
+		expect(text).toMatch(/^[01]+$/);
+	});
+
+	test("should copy sequencers with colors", async () => {
+		await page.locator('[data-testid="column-settings-dropdown"]').first().click();
+		await page.getByText("Copy Sequencers (with colors)").click();
+
+		const text = await page.evaluate(() => navigator.clipboard.readText());
+		const entries = text.split(",");
+		expect(entries.length).toBeGreaterThan(0);
+		for (const entry of entries) {
+			expect(entry).toMatch(/^(none|[a-zA-Z0-9_]+)$/);
+		}
 	});
 
 	test("should export and validate the file with the changes", async () => {

--- a/test/e2e/1-basic/columnSettingsDropdown.spec.ts
+++ b/test/e2e/1-basic/columnSettingsDropdown.spec.ts
@@ -81,12 +81,12 @@ test.describe.serial("ColumnSettingsDropdown", () => {
 		await expect(page.locator(".swal2-validation-message")).not.toBeVisible();
 	});
 
-	test("should copy sequencers as binary", async () => {
+	test("should copy sequencers as decimal", async () => {
 		await page.locator('[data-testid="column-settings-dropdown"]').first().click();
-		await page.getByText("Copy Sequencers (binary)").click();
+		await page.getByText("Copy Sequencers (decimal)").click();
 
 		const text = await page.evaluate(() => navigator.clipboard.readText());
-		expect(text).toMatch(/^[01]+$/);
+		expect(text).toMatch(/^\d+$/);
 	});
 
 	test("should copy sequencers with colors", async () => {


### PR DESCRIPTION
This pull request enhances the `ColumnSettingsDropdown` component by adding a new option to copy sequencer data as a binary string and refines the existing copy functionality to clarify its output format. It also updates the end-to-end tests to cover these new features, including clipboard permissions.

**New Features and UI Improvements:**

* Added a new menu item in `ColumnSettingsDropdown` to copy sequencer data as a binary string, using the new `handleBinaryCopySequencers` callback. [[1]](diffhunk://#diff-a7ea583874a8b6ae8ce7e6fcb29dbafce1a75a8feb30978ff36bd0f8c40aca87L129-R144) [[2]](diffhunk://#diff-a7ea583874a8b6ae8ce7e6fcb29dbafce1a75a8feb30978ff36bd0f8c40aca87R200-R210)
* Renamed the existing "Copy Sequencers" option to "Copy Sequencers (with colors)" for clarity and implemented a dedicated handler that copies color values as a comma-separated string. [[1]](diffhunk://#diff-a7ea583874a8b6ae8ce7e6fcb29dbafce1a75a8feb30978ff36bd0f8c40aca87L129-R144) [[2]](diffhunk://#diff-a7ea583874a8b6ae8ce7e6fcb29dbafce1a75a8feb30978ff36bd0f8c40aca87R200-R210)

**Testing Enhancements:**

* Updated Playwright test setup to request clipboard permissions, enabling clipboard-related tests to run reliably.
* Added end-to-end tests to verify both the binary and color-based sequencer copy functionalities, ensuring correct clipboard output formats.