### PR TITLE
:recycle: separate settings declarations from store state

### DIFF
--- a/src/app/editor/components/ColumnSettingsDropdown/index.js
+++ b/src/app/editor/components/ColumnSettingsDropdown/index.js
@@ -18,7 +18,7 @@ import { Modal } from "@/utils/modal";
 const ColumnSettingsDropdown = ({ columnIndex }) => {
 	const lights = useEditorStore((state) => state.lights);
 	const updateLights = useEditorStore((state) => state.updateLights);
-	const totalRows = useSettingsStore((state) => state.settings.totalRows.value);
+	const totalRows = useSettingsStore((state) => state.settings.totalRows);
 	const data = useMemo(
 		() =>
 			lights[0]?.[columnIndex] ?? JSON.parse(JSON.stringify(defaultLightModel)),

--- a/src/app/editor/components/Editor/index.js
+++ b/src/app/editor/components/Editor/index.js
@@ -15,15 +15,15 @@ export default function Editor() {
 		<main className="mx-auto flex w-fit flex-col gap-y-6 overflow-x-auto">
 			<EditorHeader />
 			<EditorPreview
-				totalColumns={totalColumns.value}
-				totalRows={totalRows.value}
+				totalColumns={totalColumns}
+				totalRows={totalRows}
 				currentRow={currentRow}
 				setCurrentRow={setCurrentRow}
 				bpm={bpm}
 			/>
 			<EditorGrid
-				totalColumns={totalColumns.value}
-				totalRows={totalRows.value}
+				totalColumns={totalColumns}
+				totalRows={totalRows}
 				currentRow={currentRow}
 			/>
 		</main>

--- a/src/app/editor/components/SeparatorsContainer/index.tsx
+++ b/src/app/editor/components/SeparatorsContainer/index.tsx
@@ -11,6 +11,7 @@ interface SeparatorItem {
 
 export default function SeparatorsContainer() {
 	const separatorsVisible = useSettingsStore((state) => state.settings.separatorsVisible);
+
 	const [separators, setSeparators] = useState<SeparatorItem[]>([]);
 
 	const removeSeparator = useCallback((id: string) => {
@@ -23,7 +24,7 @@ export default function SeparatorsContainer() {
 
 	useEffect(() => {
 		const handleKeyup = (e: KeyboardEvent) => {
-			if (!separatorsVisible.value) return;
+			if (!separatorsVisible) return;
 			if (document.querySelector("input:focus")) return;
 
 			if (e.key === "q") {
@@ -35,9 +36,9 @@ export default function SeparatorsContainer() {
 		return () => {
 			window.removeEventListener("keyup", handleKeyup);
 		};
-	}, [separatorsVisible.value]);
+	}, [separatorsVisible]);
 
-	if (!separatorsVisible.value) return null;
+	if (!separatorsVisible) return null;
 
 	return (
 		<>

--- a/src/app/editor/components/Toolbar/index.tsx
+++ b/src/app/editor/components/Toolbar/index.tsx
@@ -10,6 +10,7 @@ import * as Sentry from "@sentry/nextjs";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { twMerge } from "tailwind-merge";
 import { Input } from "@/components/Input";
+import { settingsConfig } from "@/config/settings.config";
 import { event } from "@/gtag";
 import { createCustomColor } from "@/services/color-manager.service";
 import { exportXmlFile, importXmlFile } from "@/services/xml-file.service";
@@ -217,7 +218,7 @@ export default function Toolbar() {
 						event({
 							action: "file_export",
 							category: "editor",
-							label: `${settings.totalColumns.value} columns - ${bpm} BPM`,
+							label: `${settings.totalColumns} columns - ${bpm} BPM`,
 						});
 
 						setUploadData({
@@ -327,9 +328,9 @@ export default function Toolbar() {
 	}, [setSelectedColor]);
 
 	const isExportDisabled =
-		!settings.oneColorPerColumn.value ||
-		settings.totalRows.value !== 32 ||
-		settings.totalColumns.value > 32;
+		!settings.oneColorPerColumn ||
+		(settings.totalRows as number) !== 32 ||
+		(settings.totalColumns as number) > 32;
 
 	return (
 		<>
@@ -505,61 +506,59 @@ export default function Toolbar() {
 						id="toolbar-settings"
 						className="mt-4 flex flex-col gap-y-2 text-gray-300 text-xs"
 					>
-						{Object.entries(settings)
-							.filter(
-								([, settingsData]: [string, any]) =>
-									!settingsData.unlisted && typeof settingsData === "object",
-							)
-							.map(([settingsId, settingsData]: [string, any]) => (
-								<div key={settingsId} className="flex flex-col gap-y-1">
-									<div className="flex items-center justify-between gap-x-2">
-										<Input
-											className={twMerge(
-												"rounded-md text-emerald-400 accent-emerald-400 outline-none focus:ring-0",
-												settingsData.attributes?.type === "range" && "w-full",
-											)}
-											id={`settings-${settingsId}`}
-											checked={settingsData.value}
-											value={settingsData.value}
-											onChange={(e) =>
-												updateSettings({
-													key: settingsId,
-													value: e.target.value,
-												})
-											}
-											{...(settingsData.attributes ?? {})}
-										/>
-										{settingsData.attributes?.type === "range" && (
+						{Object.entries(settingsConfig)
+							.filter(([_, decl]) => !decl.unlisted)
+							.map(([settingsId, decl]) => {
+								const value = settings[settingsId as keyof typeof settings];
+								return (
+									<div key={settingsId} className="flex flex-col gap-y-1">
+										<div className="flex items-center justify-between gap-x-2">
 											<Input
-												type="number"
-												min={settingsData.attributes.min}
-												max={settingsData.attributes.max}
-												value={settingsData.value}
-												className="w-12 py-0.5"
+												className={twMerge(
+													"rounded-md text-emerald-400 accent-emerald-400 outline-none focus:ring-0",
+													decl.attributes.type === "range" && "w-full",
+												)}
+												id={`settings-${settingsId}`}
+												checked={value as boolean}
+												value={value as number | string}
 												onChange={(e) =>
 													updateSettings({
-														key: settingsId,
+														key: settingsId as keyof typeof settings,
 														value: e.target.value,
 													})
 												}
+												{...decl.attributes}
 											/>
-										)}
+											{decl.attributes.type === "range" && (
+												<Input
+													type="number"
+													min={decl.attributes.min}
+													max={decl.attributes.max}
+													value={value as number}
+													className="w-12 py-0.5"
+													onChange={(e) =>
+														updateSettings({
+															key: settingsId as keyof typeof settings,
+															value: e.target.value,
+														})
+													}
+												/>
+											)}
+										</div>
+										<label htmlFor={`settings-${settingsId}`}>
+											<h5 className="font-semibold text-sm text-white">
+												{decl.label}
+											</h5>
+											{"description" in decl && decl.description && (
+												<p>{decl.description}</p>
+											)}
+											{"negativeEffect" in decl && decl.negativeEffect && (
+												<p className="text-amber-500">{decl.negativeEffect}</p>
+											)}
+										</label>
 									</div>
-									<label htmlFor={`settings-${settingsId}`}>
-										<h5 className="font-semibold text-sm text-white">
-											{settingsData.label}
-										</h5>
-										{settingsData.description && (
-											<p>{settingsData.description}</p>
-										)}
-										{settingsData.negativeEffect && (
-											<p className="text-amber-500">
-												{settingsData.negativeEffect}
-											</p>
-										)}
-									</label>
-								</div>
-							))}
+								);
+							})}
 					</div>
 				</div>
 

--- a/src/config/settings.config.ts
+++ b/src/config/settings.config.ts
@@ -1,0 +1,61 @@
+export type SettingType = "boolean" | "number";
+
+export interface SettingAttributes {
+	type: "checkbox" | "range";
+	min?: number;
+	max?: number;
+}
+
+export interface SettingDeclaration<T = boolean | number> {
+	label: string;
+	description?: string;
+	negativeEffect?: string;
+	attributes: SettingAttributes;
+	type: SettingType;
+	defaultValue: T;
+	unlisted?: boolean;
+}
+
+export const settingsConfig: Record<string, SettingDeclaration> = {
+	separatorsVisible: {
+		label: "Show/hide separators",
+		description: "This will show the created separators.",
+		attributes: { type: "checkbox" },
+		type: "boolean",
+		defaultValue: true,
+	},
+	oneColorPerColumn: {
+		label: "Limit one color per column",
+		description: "This is useful for visualizing your pattern.",
+		negativeEffect: "If disabled, you won't be able to export files.",
+		attributes: { type: "checkbox" },
+		type: "boolean",
+		defaultValue: true,
+	},
+	totalColumns: {
+		label: "Total of columns",
+		description: "This is the total columns of the editor. Default is 20.",
+		negativeEffect: "If greater than 32, you won't be able to export files.",
+		attributes: { type: "range", min: 1, max: 50 },
+		type: "number",
+		defaultValue: 20,
+	},
+	totalRows: {
+		label: "Total of rows",
+		description: "This is the total rows of the editor. Default is 32.",
+		negativeEffect: "If different than 32, you won't be able to export files.",
+		attributes: { type: "range", min: 1, max: 100 },
+		type: "number",
+		defaultValue: 32,
+	},
+} as const;
+
+export type SettingKey = keyof typeof settingsConfig;
+
+export type SettingsValues = {
+	[K in SettingKey]: typeof settingsConfig[K]["defaultValue"];
+};
+
+export const defaultSettingsValues: SettingsValues = Object.fromEntries(
+	Object.entries(settingsConfig).map(([key, decl]) => [key, decl.defaultValue]),
+) as SettingsValues;

--- a/src/hooks/useEditor.js
+++ b/src/hooks/useEditor.js
@@ -8,7 +8,7 @@ export function useOneColorPerColumn() {
   const oneColorPerColumn = useSettingsStore((state) => state.settings.oneColorPerColumn);
 
   useEffect(() => {
-    if (!oneColorPerColumn.value) return;
+    if (!oneColorPerColumn) return;
 
     let hasChanges = false;
     const newLights = { ...lights };
@@ -50,7 +50,7 @@ export function useOneColorPerColumn() {
     if (hasChanges) {
       updateLights(newLights);
     }
-  }, [oneColorPerColumn.value, lights, updateLights]);
+  }, [oneColorPerColumn, lights, updateLights]);
 }
 
 export function usePreventContextMenu() {

--- a/src/services/siren-transformer.service.ts
+++ b/src/services/siren-transformer.service.ts
@@ -158,7 +158,7 @@ export const exportSirenData = (editor: any, settings: any): [string, any] => {
 
 		for (
 			let columnIndex = 0;
-			columnIndex < settings.totalColumns.value;
+			columnIndex < settings.totalColumns;
 			columnIndex++
 		) {
 			let light = row[columnIndex];

--- a/src/store/editor.store.ts
+++ b/src/store/editor.store.ts
@@ -29,7 +29,7 @@ interface EditorState {
 		row: number;
 		column: number;
 		color: string;
-		isOneColorPerColumn: { value: boolean };
+		isOneColorPerColumn: boolean;
 	}) => void;
 	updateLights: (lights: EditorState["lights"]) => void;
 }
@@ -90,7 +90,7 @@ export const useEditorStore = create<EditorState>()(
 						newLights[row][column] = defaultLightModel;
 					}
 
-					if (isOneColorPerColumn.value) {
+					if (isOneColorPerColumn) {
 						for (const rowKey of Object.keys(newLights)) {
 							const currentRow = newLights[rowKey as any];
 							if (

--- a/src/store/settings.store.ts
+++ b/src/store/settings.store.ts
@@ -1,94 +1,55 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import {
+	defaultSettingsValues,
+	type SettingKey,
+	type SettingsValues,
+	settingsConfig,
+} from "@/config/settings.config";
 import { STORE_KEY } from "./constants";
 
+interface SettingsState {
+	settings: SettingsValues;
+	updateSettings: (payload: { key: SettingKey; value: unknown }) => void;
+}
 
-export const useSettingsStore = create<any>()(
+export const useSettingsStore = create<SettingsState>()(
 	persist(
 		(set) => ({
-			settings: {
-				separatorsVisible: {
-					label: "Show/hide separators",
-					description: "This will show the created separators.",
-					attributes: {
-						type: "checkbox",
-					},
-					type: "boolean",
-					value: true,
-				},
-				oneColorPerColumn: {
-					label: "Limit one color per column",
-					description: "This is useful for visualizing your pattern.",
-					negativeEffect: "If disabled, you won't be able to export files.",
-					attributes: {
-						type: "checkbox",
-					},
-					type: "boolean",
-					value: true,
-				},
-				totalColumns: {
-					label: "Total of columns",
-					description: "This is the total columns of the editor. Default is 20.",
-					// if greater than 32, you'll not be able to export files
-					negativeEffect: "If greater than 32, you won't be able to export files.",
-					attributes: {
-						type: "range",
-						min: 1,
-						max: 50,
-					},
-					type: "number",
-					value: 20,
-				},
-				totalRows: {
-					label: "Total of rows",
-					description: "This is the total rows of the editor. Default is 32.",
-					// if != 32, you'll not be able to export files
-					negativeEffect: "If different than 32, you won't be able to export files.",
-					attributes: {
-						type: "range",
-						min: 1,
-						max: 100,
-					},
-					type: "number",
-					value: 32,
-				},
-			},
+			settings: { ...defaultSettingsValues },
 
-			// Actions
-			// TODO: Add types to the actions
-			updateSettings: ({ key, value }: any) =>
-				set((state: any) => {
-					let processedValue = value;
+			updateSettings: ({ key, value }) =>
+				set((state) => {
+					const declaration = settingsConfig[key];
+					if (!declaration) return state;
 
-					if (state.settings[key].attributes?.type === "checkbox") {
+					let processedValue: boolean | number;
+					if (declaration.attributes.type === "checkbox") {
 						processedValue = !(value === "true");
-					}
-
-					if (state.settings[key].type === "number") {
+					} else if (declaration.type === "number") {
 						processedValue = Number(value);
+					} else {
+						processedValue = value as boolean | number;
 					}
 
 					return {
 						settings: {
 							...state.settings,
-							[key]: {
-								...state.settings[key],
-								value: processedValue,
-							},
+							[key]: processedValue,
 						},
-					}
+					};
 				}),
 		}),
 		{
 			name: `${STORE_KEY}settings`,
-			version: 2,
+			version: 3,
 			migrate(persistedState, version) {
-				if (version !== 2) {
+				if (version !== 3) {
 					useSettingsStore.persist.clearStorage();
-					return {} as any; // Return an empty state to reset to defaults
+					return { settings: { ...defaultSettingsValues } } as SettingsState;
 				}
-				return persistedState;
+				return persistedState as SettingsState;
 			},
-		}
-	)
+		},
+	),
 );


### PR DESCRIPTION
Move setting metadata (label, description, attributes, min/max, defaults) out of the Zustand store into a standalone settings.config.ts. Store now holds raw values keyed by setting name, eliminating the .value indirection across consumers.

Bump persisted store version to 3 to discard the previous { value } wrapped shape. updateLight signature switches isOneColorPerColumn from { value: boolean } to boolean.