### PR TITLE
🐛 fix DOM crashes when Google Translate is active

### DIFF
--- a/src/app/editor/components/Editor/EditorHeader.tsx
+++ b/src/app/editor/components/Editor/EditorHeader.tsx
@@ -53,7 +53,7 @@ export default function EditorHeader() {
 			>
 				<FontAwesomeIcon icon={faGithub} />
 				<span className="text-sm">
-					Star on GitHub
+					<span>Star on GitHub</span>
 					{count > 0 && (
 						<span className="ml-2 text-white/40 text-xs">
 							<FontAwesomeIcon icon={faStar} /> {count}

--- a/src/app/editor/components/Toolbar/index.tsx
+++ b/src/app/editor/components/Toolbar/index.tsx
@@ -451,7 +451,7 @@ export default function Toolbar() {
 												</span>
 											)}
 										</button>
-										{colorData.toolbar.name}
+										<span>{colorData.toolbar.name}</span>
 									</div>
 								);
 							})}
@@ -473,7 +473,7 @@ export default function Toolbar() {
 									className="text-2xl drop-shadow-[0px_2px_1px_#000]"
 								/>
 							</button>
-							Custom
+							<span>Custom</span>
 						</div>
 					</div>
 				</div>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -30,7 +30,7 @@ export default function ErrorPage({
 
 			{error.digest ? (
 				<p>
-					Error ID: <code>{error.digest}</code>
+					<span>Error ID:</span> <code>{error.digest}</code>
 				</p>
 			) : null}
 		</div>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -37,7 +37,7 @@ export default function GlobalError({
 
 					{error.digest ? (
 						<p>
-							Error ID: <code>{error.digest}</code>
+							<span>Error ID:</span> <code>{error.digest}</code>
 						</p>
 					) : null}
 				</div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,9 @@ import "./styles/modals.css";
 import { config } from "@fortawesome/fontawesome-svg-core";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
 import MotionProvider from "@/components/MotionProvider";
+import TranslateCompat from "@/components/TranslateCompat";
 import "@fortawesome/fontawesome-svg-core/styles.css";
+
 config.autoAddCss = false;
 
 export const metadata = {
@@ -36,6 +38,7 @@ export default function RootLayout({
 	return (
 		<html lang="en" data-scroll-behavior="smooth">
 			<body className="dark bg-slate-950" suppressHydrationWarning>
+				<TranslateCompat />
 				<GoogleAnalytics />
 				<MotionProvider>{children}</MotionProvider>
 			</body>

--- a/src/components/TranslateCompat/index.tsx
+++ b/src/components/TranslateCompat/index.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Google Translate rewrites text nodes in place, wrapping them in <font> elements.
+ * React still holds a reference to the original text node and to the parent it was
+ * mounted under, so a later render that removes or reorders that node throws
+ * "NotFoundError: Failed to execute 'removeChild' on 'Node'" (or 'insertBefore').
+ *
+ * These patches make both operations tolerant: if the node is no longer a direct
+ * child of the parent React expects, we act on wherever Translate actually put it
+ * instead of throwing. React's virtual DOM stays authoritative, and the page
+ * remains translatable.
+ *
+ * See https://github.com/facebook/react/issues/11538
+ */
+export default function TranslateCompat() {
+	useEffect(() => {
+		const originalRemoveChild = Node.prototype.removeChild;
+		const originalInsertBefore = Node.prototype.insertBefore;
+
+		Node.prototype.removeChild = function removeChild<T extends Node>(
+			this: Node,
+			child: T,
+		): T {
+			if (child.parentNode !== this) {
+				child.parentNode?.removeChild(child);
+				return child;
+			}
+			return originalRemoveChild.call(this, child) as T;
+		};
+
+		Node.prototype.insertBefore = function insertBefore<T extends Node>(
+			this: Node,
+			newNode: T,
+			referenceNode: Node | null,
+		): T {
+			if (referenceNode && referenceNode.parentNode !== this) {
+				return this.appendChild(newNode) as T;
+			}
+			return originalInsertBefore.call(this, newNode, referenceNode) as T;
+		};
+
+		return () => {
+			Node.prototype.removeChild = originalRemoveChild;
+			Node.prototype.insertBefore = originalInsertBefore;
+		};
+	}, []);
+
+	return null;
+}


### PR DESCRIPTION
Google Translate rewrites text nodes in place, wrapping them in <font> elements. React keeps a reference to the original text node and to the parent it mounted under, so a later render that removes or reorders that node throws "NotFoundError: Failed to execute 'removeChild' on 'Node'", alongside hydration mismatches.

- add TranslateCompat, which makes removeChild/insertBefore tolerant of nodes Translate has reparented instead of letting them throw
- wrap loose text nodes that sit next to conditionally rendered siblings, the shape that actually trips React (Toolbar, EditorHeader, error pages)

The page stays fully translatable — no notranslate opt-out.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
